### PR TITLE
Allow building images without extension script and enable BuildKit

### DIFF
--- a/app.sh
+++ b/app.sh
@@ -82,14 +82,18 @@ echo "${IMAGE_NAME_SPECIFIC_RELEASE} or ${IMAGE_NAME_LATEST} "
 function build() {
     # autopep8 --recursive --exclude=.git,__pycache__,venv --max-line-length=120 --in-place .
     cmd="docker build --no-cache -t ${IMAGE_NAME_SPECIFIC_RELEASE} --build-arg DOCKER_ANDROID_VERSION=${r_v} "
+    ext=""
+    if [ -f extension.sh ]; then
+        ext="--secret id=extension,src=extension.sh "
+    fi
     if [ -n "${a_v}" ]; then
         DOCKER_BUILDKIT=1
-        cmd="${cmd} --secret id=extension,src=extension.sh --build-arg EMULATOR_ANDROID_VERSION=${a_v} --build-arg EMULATOR_API_LEVEL=${a_l} "
+        cmd="${cmd} ${ext}--build-arg EMULATOR_ANDROID_VERSION=${a_v} --build-arg EMULATOR_API_LEVEL=${a_l} "
     fi
 
     if [[ "${p}" == *"genymotion"* ]]; then
         DOCKER_BUILDKIT=1
-        cmd="${cmd} --secret id=extension,src=extension.sh "
+        cmd="${cmd} ${ext}"
     fi
 
     cmd+="-f ${FOLDER_PATH} ."

--- a/docker/base
+++ b/docker/base
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 FROM appium/appium:v2.19.0-p3
 
 ARG AUTHORS="Budi Utomo"

--- a/docker/emulator
+++ b/docker/emulator
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 ARG DOCKER_ANDROID_VERSION
 FROM budtmo/docker-android:base_${DOCKER_ANDROID_VERSION}
 
@@ -83,8 +84,8 @@ ENV APP_PATH=${WORK_PATH}/${SCRIPT_PATH}
 RUN mkdir -p ${APP_PATH}
 COPY mixins ${APP_PATH}/mixins
 COPY cli ${APP_PATH}/cli
-RUN --mount=type=secret,id=extension,dst=/tmp/extension.sh \
-    bash /tmp/extension.sh
+RUN --mount=type=secret,id=extension,dst=/tmp/extension.sh,required=false \
+    if [ -f /tmp/extension.sh ]; then bash /tmp/extension.sh; fi
 
 #===================
 # Configure OpenBox

--- a/docker/genymotion
+++ b/docker/genymotion
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 ARG DOCKER_ANDROID_VERSION
 FROM budtmo/docker-android:base_${DOCKER_ANDROID_VERSION}
 
@@ -35,8 +36,8 @@ ENV APP_PATH=${WORK_PATH}/${SCRIPT_PATH}
 RUN mkdir -p ${APP_PATH}
 COPY mixins ${APP_PATH}/mixins
 COPY cli ${APP_PATH}/cli
-RUN --mount=type=secret,id=extension,dst=/tmp/extension.sh \
-    bash /tmp/extension.sh
+RUN --mount=type=secret,id=extension,dst=/tmp/extension.sh,required=false \
+    if [ -f /tmp/extension.sh ]; then bash /tmp/extension.sh; fi
 
 #===================================
 # Create Genymotion Template folder


### PR DESCRIPTION
## Summary
- enable Docker BuildKit in all Dockerfiles via `# syntax` directive
- make extension script optional during builds
- skip passing build secret when `extension.sh` is missing

## Testing
- `bash -n app.sh`


------
https://chatgpt.com/codex/tasks/task_e_688d2bc31b748326aef430be98cdcf31